### PR TITLE
Fix put_config_vars

### DIFF
--- a/lib/config_vars.js
+++ b/lib/config_vars.js
@@ -22,9 +22,7 @@
       return this.request({
         method: "PUT",
         path: "/apps/" + app + "/config_vars",
-        query: {
-          body: JSON.stringify(vars)
-        }
+        query: vars
       }, fn);
     };
     return ConfigVars;

--- a/src/config_vars.coffee
+++ b/src/config_vars.coffee
@@ -13,5 +13,4 @@ class module.exports.ConfigVars
     @request {
       method : "PUT",
       path   : "/apps/#{app}/config_vars",
-      query  : 
-        body : JSON.stringify vars}, fn
+      query  : vars}, fn


### PR DESCRIPTION
put_config_vars was placing the var and value inside of a "body" attribute, causing a config var of "body" to get created with a JSON value of "{var: value}". This fixes that
